### PR TITLE
fix offset when using last and before together

### DIFF
--- a/lib/cursor-paginator.js
+++ b/lib/cursor-paginator.js
@@ -90,7 +90,10 @@ export default () => {
 
       if (last) {
         let offset = totalCount - last - (hasOffset ? 1 : 0);
-        if (before) offset -= 1;
+        if (before) {
+          const dataCount = await this.countDocuments(dataQuery);
+          offset = dataCount - last - 1;
+        }
         skip = offset < 0 ? 0 : offset;
       }
 


### PR DESCRIPTION
Thanks for great packages, tiny fix is needed.
There is incorrect offset when using last and before together.

Right now:
20 items in the database, ids 0-19
{ last: 5 } returns 5 nodes with ids 15-19 and startCursor
{ last: 5, before: 'STARTCURSOR' } returns incorrectly 2 nodes, ids 13-14

After this pull request:
{ last: 5, before: 'STARTCURSOR' } returns correctly 5 nodes with ids 10-14
